### PR TITLE
Fix CVE-2020-14933

### DIFF
--- a/patches/CVE-2020-14933.patch
+++ b/patches/CVE-2020-14933.patch
@@ -1,0 +1,95 @@
+Index: squirrelmail-1.4.23~svn20120406/src/compose.php
+===================================================================
+--- squirrelmail-1.4.23~svn20120406.orig/src/compose.php
++++ squirrelmail-1.4.23~svn20120406/src/compose.php
+@@ -285,6 +285,43 @@ function getforwardHeader($orig_header)
+         "\n\n";
+     return $bodyTop;
+ }
++
++function encodeAttachments($attachments) {
++    $data = array();
++
++    foreach ($attachments as $attachment) {
++        $type = implode("/", array($attachment->mime_header->type0, $attachment->mime_header->type1));
++        $data[] = array("type" => $type, "name" => $attachment->mime_header->getParameter("name"), "location" => $attachment->att_local_name);
++    }
++
++    return json_encode($data);
++}
++
++function decodeAttachments($attachments) {
++    $msg = new Message();
++
++    $attachments = json_decode($attachments);
++    if (is_array($attachments)) {
++        // sanitize the "location" since it is user-supplied and used to access the file system
++        // it must be alpha-numeric and 32 characters long (see the use of GenerateRandomString() below)
++        foreach ($attachments as $i => $attachment) {
++            if (empty($attachment->location) || strlen($attachment->location) !== 32) {
++                continue;
++            }
++            if (preg_match('/[^0-9a-zA-Z]/', $attachment->location)) {
++                continue;
++            }
++
++            if (!isset($attachment->type) || !isset($attachment->name)) {
++                continue;
++            }
++
++            $msg->initAttachment($attachment->type, $attachment->name, $attachment->location);
++        }
++    }
++
++    return $msg->entities;
++}
+ /* ----------------------------------------------------------------------- */
+ 
+ /*
+@@ -318,7 +355,7 @@ if (sqsession_is_registered('session_exp
+         }
+ 
+         if (!empty($attachments)) 
+-            $attachments = unserialize($attachments);
++            $attachments = decodeAttachments($attachments);
+ 
+         sqsession_register($composesession,'composesession');
+ 
+@@ -368,26 +405,8 @@ if (!empty($compose_messages[$session]))
+ // FIXME: note that technically this is very bad form - 
+ // should never directly manipulate an object like this
+ if (!empty($attachments)) {
+-    $attachments = unserialize($attachments);
+-    if (!empty($attachments) && is_array($attachments)) {
+-        // sanitize the "att_local_name" since it is user-supplied and used to access the file system
+-        // it must be alpha-numeric and 32 characters long (see the use of GenerateRandomString() below)
+-        foreach ($attachments as $i => $attachment) {
+-            if (empty($attachment->att_local_name) || strlen($attachment->att_local_name) !== 32) {
+-                unset($attachments[$i]);
+-                continue;
+-            }
+-            // probably marginal difference between (ctype_alnum + function_exists) and preg_match
+-            if (function_exists('ctype_alnum')) {
+-                if (!ctype_alnum($attachment->att_local_name))
+-                    unset($attachments[$i]);
+-            }
+-            else if (preg_match('/[^0-9a-zA-Z]/', $attachment->att_local_name))
+-                unset($attachments[$i]);
+-        }
+-        if (!empty($attachments))
+-            $composeMessage->entities = $attachments;
+-    }
++    $attachments = decodeAttachments($attachments);
++    $composeMessage->entities = $attachments;
+ }
+ 
+ if (!isset($mailbox) || $mailbox == '' || ($mailbox == 'None')) {
+@@ -1375,7 +1394,7 @@ function showInputForm ($session, $value
+     echo addHidden('composesession', $composesession).
+         addHidden('querystring', $queryString).
+         (!empty($attach_array) ?
+-        addHidden('attachments', serialize($attach_array)) : '').
++        addHidden('attachments', encodeAttachments($attach_array)) : '').
+         "</form>\n";
+     if (!(bool) ini_get('file_uploads')) {
+         /* File uploads are off, so we didn't show that part of the form.


### PR DESCRIPTION
Convert the data required for attachments into a simple array and then recreate the object array on decode.

The fix for CVE-2018-8741 looks incomplete because "attachments" is deserialized in two places but the filenames are only checked in one of them. This check is now made every time "attachments" is decoded.
